### PR TITLE
bugfix/advice-firefox

### DIFF
--- a/helpers/generateRandomString.js
+++ b/helpers/generateRandomString.js
@@ -1,0 +1,12 @@
+export function generateRandomString(length) {
+  let result = "";
+  const characters =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const charactersLength = characters.length;
+  let counter = 0;
+  while (counter < length) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    counter += 1;
+  }
+  return result;
+}

--- a/pages/advice/index.js
+++ b/pages/advice/index.js
@@ -3,10 +3,13 @@ import { useState } from "react";
 import Footer from "../../components/Footer";
 import RandomButton from "../../components/RandomImageButton";
 import RandomAdvice from "../../components/RandomAdvice";
+import { generateRandomString } from "../../helpers/generateRandomString";
+import generate from "@babel/generator";
 
 export default function Advice() {
   const [advice, setAdvice] = useState("");
-  const url = "https://api.adviceslip.com/advice";
+  const url =
+    "https://api.adviceslip.com/advice?random=" + generateRandomString(12);
 
   async function fetchAdvice() {
     try {

--- a/pages/advice/index.js
+++ b/pages/advice/index.js
@@ -4,7 +4,6 @@ import Footer from "../../components/Footer";
 import RandomButton from "../../components/RandomImageButton";
 import RandomAdvice from "../../components/RandomAdvice";
 import { generateRandomString } from "../../helpers/generateRandomString";
-import generate from "@babel/generator";
 
 export default function Advice() {
   const [advice, setAdvice] = useState("");
@@ -20,10 +19,6 @@ export default function Advice() {
       console.error(error);
     }
   }
-
-  setTimeout(() => {
-    setAdvice("");
-  }, "10000");
 
   return (
     <StyledAdvicePage>

--- a/pages/advice/index.js
+++ b/pages/advice/index.js
@@ -6,16 +6,21 @@ import RandomAdvice from "../../components/RandomAdvice";
 
 export default function Advice() {
   const [advice, setAdvice] = useState("");
+  const url = "https://api.adviceslip.com/advice";
 
   async function fetchAdvice() {
     try {
-      const response = await fetch("https://api.adviceslip.com/advice");
+      const response = await fetch(url);
       const data = await response.json();
       setAdvice(data.slip);
     } catch (error) {
       console.error(error);
     }
   }
+
+  setTimeout(() => {
+    setAdvice("");
+  }, "10000");
 
   return (
     <StyledAdvicePage>


### PR DESCRIPTION
in firefox, clicking the advice button (fuer-johanna.vercel.app/advice) multiple times always returns the same object. in chrome it's working perfectly. I don't know what's happening. 

things I tried: 
* set the advice object without a state - no effect
* accessed the API url in firefox by itself - refreshing the page returns a new piece of advice, so this is working fine
* setTimeout to reset the advice state - no effect

FINAL SOLUTION: 
Firefox caches get requests --> make each request unique by adding a random string to the url (`?random=123abc456def`) 